### PR TITLE
Devfile and other updates

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.0
 metadata:
   name: inventory-quarkus
 attributes:
@@ -15,30 +15,23 @@ components:
           name: debug
           protocol: tcp
           targetPort: 5005
+        - exposure: none
+          name: test
+          protocol: http
+          targetPort: 8081
         - exposure: public
           name: inventory
           protocol: http
           targetPort: 8080
           path: /
-      volumeMounts:
-        - name: m2
-          path: /home/user/.m2
+      memoryRequest: 5Mi
       memoryLimit: 6G
-      mountSources: true
-  - name: ubi-minimal
-    container:
-      image: registry.access.redhat.com/ubi8/ubi-minimal
-      command: ['tail']
-      args: ['-f', '/dev/null']
-      memoryLimit: 64M
-      mountSources: true
-  - name: m2
-    volume:
-      size: 1G
+      cpuRequest: 1000m
+      cpuLimit: 4000m
 commands:
   - id: package
     exec:
-      label: "Package"
+      label: "1. Package"
       component: tools
       workingDir: ${PROJECTS_ROOT}/inventory-quarkus
       commandLine: "./mvnw clean package -DskipTests=true"
@@ -47,7 +40,7 @@ commands:
         isDefault: true
   - id: runtests
     exec:
-      label: "Run Tests"
+      label: "2. Run Tests"
       component: tools
       workingDir: ${PROJECTS_ROOT}/inventory-quarkus
       commandLine: "./mvnw test"
@@ -55,7 +48,7 @@ commands:
         kind: test
   - id: startdev
     exec:
-      label: "Start Development mode (Hot reload + debug)"
+      label: "3. Start Development mode (Hot reload + debug)"
       component: tools
       workingDir: ${PROJECTS_ROOT}/inventory-quarkus
       commandLine: "./mvnw compile quarkus:dev"
@@ -64,17 +57,25 @@ commands:
         isDefault: true
   - id: buildimage
     exec:
-      label: "Build Image"
+      label: "4. Build Image"
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: "podman build -f src/main/docker/Dockerfile.jvm -t quay.io/che-incubator/inventory-quarkus ."
+      commandLine: |
+        IMAGE=image-registry.openshift-image-registry.svc:5000/openshift/quarkus-api-example
+        podman build -f src/main/docker/Dockerfile.jvm -t "${IMAGE}" .
       group:
         kind: build
-  - id: tag
+  - id: pushimage
     exec:
-      label: "Tag Image"
+      label: "5. Push Image"
       component: tools
-      workingDir: ${PROJECTS_ROOT}/inventory-quarkus
-      commandLine: "podman tag quay.io/coolstore-demo/inventory-quarkus:latest"
+      commandLine: |
+        # Requires `oc policy add-role-to-user registry-editor <user_name> -n openshift`
+        IMAGE=image-registry.openshift-image-registry.svc:5000/openshift/quarkus-api-example
+        podman login --tls-verify=false -u $(oc whoami) -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
+        podman push --tls-verify=false "${IMAGE}"
       group:
-        kind: test
+        kind: build
+events:
+  postStart:
+    - package

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,4 @@
+# Run `sdk env` to use the SDKs below (c.f. sdkman env command)
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.3-tem

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Great service.
 
 # Start VSCode with OpenShift DevSpaces
 
-<a href="https://devspaces.apps.rhte.0x74.p1.openshiftapps.com/f?url=https://github.com/coolstore-demo/inventory-quarkus&policies.create=peruser" target="_blank"><img src="https://raw.githubusercontent.com/blues-man/cloud-native-workshop/demo/factory-contribute.svg" alt="Contribute"></a>
+<a href="https://workspaces.openshift.com/#https://github.com/coolstore-demo/inventory-quarkus" target="_blank"><img src="https://raw.githubusercontent.com/blues-man/cloud-native-workshop/demo/factory-contribute.svg" alt="Contribute"></a>

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Great service.
 
 # Start VSCode with OpenShift DevSpaces
 
-<a href="https://workspaces.openshift.com/#https://github.com/coolstore-demo/inventory-quarkus" target="_blank"><img src="https://raw.githubusercontent.com/blues-man/cloud-native-workshop/demo/factory-contribute.svg" alt="Contribute"></a>
+<a href="https://devspaces.apps.rhte.0x74.p1.openshiftapps.com/#https://github.com/coolstore-demo/inventory-quarkus" target="_blank"><img src="https://raw.githubusercontent.com/blues-man/cloud-native-workshop/demo/factory-contribute.svg" alt="Contribute"></a>

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/getting-started-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ARG JAVA_PACKAGE=java-1.8.0-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.5
@@ -38,7 +38,6 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 
-COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
 
 EXPOSE 8080


### PR DESCRIPTION
A few changes to improve the UX in OpenShift Dev Spaces
- set the devfile spec version to 2.2 (latest)
- configured test endpoint with `exposure: none` to avoid notification when running tests
- removed m2 volume for consistency with the attribute `ephemeral` (and make startup faster)
- added a pre-start event to pre-package the app so that the `mvn package` command run later will be faster
- set proper cpu and memory requests/limits
- removed ubi-minimal component as it was not used
- added a command to push the just built image to the OCP registry so that it can be used to test the app in its pod
- added `.sdkmanrc` to help switching to java 17
- updated the README badge to use Developer Sandbox
- updated the Dockerfile to fix the build